### PR TITLE
Update dlcinterface.py

### DIFF
--- a/dustrack/dlcinterface.py
+++ b/dustrack/dlcinterface.py
@@ -757,7 +757,8 @@ class VideoFileManager(FileManager):
     @property
     def dlc_traces(self) -> dict:
         fm_temp = FileManager(str(Path(self.base_dir) / "videos")).add()
-        fnames = fm_temp[f'{self.video_stem}*{self.project_name}*.h5']
+        # fnames = fm_temp[f'{self.video_stem}*{self.project_name}*.h5']
+        fnames = fm_temp[f'{self.video_stem}DLC*{self.project_name}*.h5']
         return {self._get_dlc_trace_name(fname): fname for fname in fnames}
     
     @property


### PR DESCRIPTION
When the file name and the project name has same prefix, it merge those two constrains in the line: "fnames = fm_temp[f'{self.video_stem}*{self.project_name}*.h5']" So we add 'DLC' to explicitly split them:
"fnames = fm_temp[f'{self.video_stem}DLC*{self.project_name}*.h5']"